### PR TITLE
Fix for double loading tasks with gems that depend on engine, like st…

### DIFF
--- a/lib/standalone_migrations.rb
+++ b/lib/standalone_migrations.rb
@@ -13,6 +13,7 @@ railtie_app_path = "#{lib_path}/standalone_migrations/minimal_railtie_config"
 APP_PATH = File.expand_path(railtie_app_path,  __FILE__)
 
 require "standalone_migrations/minimal_railtie_config"
+require "active_record/railtie"
 require "standalone_migrations/tasks"
 
 if !ENV["RAILS_ENV"]

--- a/lib/standalone_migrations/tasks.rb
+++ b/lib/standalone_migrations/tasks.rb
@@ -24,7 +24,6 @@ module StandaloneMigrations
         ).each do
           |task| load "standalone_migrations/tasks/#{task}.rake"
         end
-        load "active_record/railties/databases.rake"
       end
     end
   end


### PR DESCRIPTION
…rong_migrations

This was originally on the `fixes` [branch](https://github.com/instacart/standalone-migrations/commit/71d9c69de9954308b166210f4d5e3f7ac680dd7e)

The issue is that without removing this `load "active_record/railties/databases.rake"`, we end up with "duplicated" tasks.

Right now: 
```
Rake::Task["db:migrate:status"].actions
=> [#<Proc:0x00007fdc6f2f2878@/[...]/active_record/railties/databases.rake:201>,
 #<Proc:0x00007fdc70827400@/[...]/active_record/railties/databases.rake:201>]
```

With this fix: 
```
Rake::Task["db:migrate:status"].actions
=> [#<Proc:0x00007face73703c0@/[...]/active_record/railties/databases.rake:125>,]
```

This leads to all kinds of issues